### PR TITLE
added vendor prefixing utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ A mixin `oUseragentVendorify` is provided to prefix css style rules with the ven
 	* `$apply-prefix-to-value` - whether to prefix the value as well as the property (defaults to `false`)
 	* `$prefixes` - space separated list of prefixes to apply, defaults to `webkit moz ms o`
 
+Within a product the variable `$o-useragent-vendor-prefixes` (which defaults to `webkit moz ms o`) can be set to alter globally which vendor prefixes should be included in the stylesheet.
+
 ## Usage for JavaScript vendor-prefixer
 
 This module also provides a javascript utility, `o-useragent.prefixer` to retrieve vendor-prefixed properties if the browser doesn't yet support it unprefixed.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -54,9 +54,11 @@
     #{$prefix + $prop}: $val;
 }
 
-@mixin oUseragentVendorify ($prop, $val, $apply-prefix-to-value: false, $prefixes: webkit moz ms o) {
+@mixin oUseragentVendorify ($prop, $val, $apply-prefix-to-value: false, $prefixes: $o-useragent-vendor-prefixes) {
 	@each $prefix in $prefixes {
-	    @include _oUseragentPrefix(#{'-' + $prefix + '-'}, $prop, $val, $apply-prefix-to-value);
+		@if (contains($o-useragent-vendor-prefixes, $prefix)) {
+		    @include _oUseragentPrefix(#{'-' + $prefix + '-'}, $prop, $val, $apply-prefix-to-value);
+		}
 	}
     #{$prop}: $val;
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,3 +3,4 @@ $o-useragent-name: o-useragent;
 $o-useragent-assets-path: $o-useragent-name !default;
 $o-useragent-version: null !default;
 $_o-useragent-targeted-useragents: () !default;
+$o-useragent-vendor-prefixes: webkit moz ms o !default;


### PR DESCRIPTION
Seems silly to me that there's so much vendor prefixing stuff in the js and none whatsoever in the CSS.

What d'you think @dansearle-ft @triblondon 

_edit_ Just added ability for products to turn off a given vendor prefix in stylesheets. With this, does this PR also merit a new _should_ rule in the spec?
